### PR TITLE
feat: expose control-plane and kube-proxy metrics for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ kubectl get csr
 kubectl certificate approve $CSR
 ```
 
+## Exposing Control Plane Metrics
+
+By default, Talos binds the metrics endpoints for etcd, the scheduler, the controller-manager, and kube-proxy to localhost, so a monitoring stack like [kube-prometheus-stack](https://github.com/zimmertr/Kubernetes-Manifests/tree/main/observability) cannot scrape them. Set `var.talos_expose_metrics` to `true` to bind them to the node addresses instead. The scheduler and controller-manager still authenticate scrapes with TLS and RBAC; etcd's metrics listener (`2381`) and kube-proxy's (`10249`) are plain HTTP, readable by anything that can reach the node network, which is why this is opt-in.
+
+On a running cluster, the scheduler, controller-manager, and API server pick the change up on their own when the configuration is applied. etcd does not: Talos refuses API-driven etcd restarts, so reboot each control plane node one at a time with `talosctl -n $NODE reboot`, verifying `talosctl etcd status` between nodes. kube-proxy is a bootstrap manifest and only re-renders on `talosctl upgrade-k8s --to $CURRENT_VERSION`.
+
 
 <hr>
 

--- a/configs/controlplane.yml
+++ b/configs/controlplane.yml
@@ -12,3 +12,23 @@ machine:
         dhcp: true
         vip:
           ip: "${talos_virtual_ip}"
+
+# Talos binds the control-plane components' metrics to localhost by default,
+# which leaves kube-prometheus-stack (Kubernetes-Manifests/observability)
+# scraping targets that can never answer. These expose them on the node
+# addresses. The scheduler and controller-manager still authenticate scrapes
+# (their metrics ports are TLS + RBAC); etcd's metrics listener and
+# kube-proxy's are plain HTTP, readable by anything on the node network.
+cluster:
+  controllerManager:
+    extraArgs:
+      bind-address: "0.0.0.0"
+  etcd:
+    extraArgs:
+      listen-metrics-urls: "http://0.0.0.0:2381"
+  proxy:
+    extraArgs:
+      metrics-bind-address: "0.0.0.0:10249"
+  scheduler:
+    extraArgs:
+      bind-address: "0.0.0.0"

--- a/configs/controlplane.yml
+++ b/configs/controlplane.yml
@@ -12,23 +12,3 @@ machine:
         dhcp: true
         vip:
           ip: "${talos_virtual_ip}"
-
-# Talos binds the control-plane components' metrics to localhost by default,
-# which leaves kube-prometheus-stack (Kubernetes-Manifests/observability)
-# scraping targets that can never answer. These expose them on the node
-# addresses. The scheduler and controller-manager still authenticate scrapes
-# (their metrics ports are TLS + RBAC); etcd's metrics listener and
-# kube-proxy's are plain HTTP, readable by anything on the node network.
-cluster:
-  controllerManager:
-    extraArgs:
-      bind-address: "0.0.0.0"
-  etcd:
-    extraArgs:
-      listen-metrics-urls: "http://0.0.0.0:2381"
-  proxy:
-    extraArgs:
-      metrics-bind-address: "0.0.0.0:10249"
-  scheduler:
-    extraArgs:
-      bind-address: "0.0.0.0"

--- a/configs/expose_metrics.yml
+++ b/configs/expose_metrics.yml
@@ -1,0 +1,21 @@
+# Applied to control planes only when var.talos_expose_metrics is true.
+#
+# Talos binds the control-plane components' metrics to localhost by default,
+# which leaves a kube-prometheus stack scraping targets that can never
+# answer. These expose them on the node addresses. The scheduler and
+# controller-manager still authenticate scrapes (their metrics ports are
+# TLS + RBAC); etcd's metrics listener and kube-proxy's are plain HTTP,
+# readable by anything on the node network — which is why this is opt-in.
+cluster:
+  controllerManager:
+    extraArgs:
+      bind-address: "0.0.0.0"
+  etcd:
+    extraArgs:
+      listen-metrics-urls: "http://0.0.0.0:2381"
+  proxy:
+    extraArgs:
+      metrics-bind-address: "0.0.0.0:10249"
+  scheduler:
+    extraArgs:
+      bind-address: "0.0.0.0"

--- a/talos_controlplanes.tf
+++ b/talos_controlplanes.tf
@@ -82,6 +82,7 @@ resource "talos_machine_configuration_apply" "controlplane" {
         talos_virtual_ip = var.talos_virtual_ip
       }),
     ],
-    var.talos_disable_flannel ? [file("configs/disable_flannel.yml")] : []
+    var.talos_disable_flannel ? [file("configs/disable_flannel.yml")] : [],
+    var.talos_expose_metrics ? [file("configs/expose_metrics.yml")] : []
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,11 @@ variable "talos_disable_flannel" {
   default     = false
   description = "Whether or not the Flannel CNI & Kube Proxy should be disabled for Cilium"
 }
+variable "talos_expose_metrics" {
+  type        = bool
+  default     = false
+  description = "Whether or not etcd, the scheduler, the controller-manager, and kube-proxy should serve Prometheus metrics on the node addresses instead of localhost"
+}
 variable "controlplane_ip_prefix" {
   # While I use DHCP reservation to assign IP Addresses to each virtual machine, talos must know
   # the IP Address of a node in order to apply configuration and bootstrap it. This prefix is used

--- a/vars/stable.tfvars
+++ b/vars/stable.tfvars
@@ -7,6 +7,7 @@ proxmox_resource_pool           = "Kubernetes-Stable"
 # Talos #########################
 talos_image_node_name           = "earth"
 talos_virtual_ip                = "192.168.40.10"
+talos_expose_metrics            = true
 
 
 # Kubernetes ####################


### PR DESCRIPTION
Requested in review of zimmertr/Kubernetes-Manifests#658 (the kube-prometheus-stack enable, part of zimmertr/bluebird#77).

## Summary

Talos binds the control-plane metrics endpoints to localhost by default. Probed from the LAN against `k8s-cp-1`: etcd metrics (2381), kube-scheduler (10259), and kube-controller-manager (10257) all refuse, so the kube-prometheus-stack scrape targets for them can never answer.

**Opt-in by variable** (second commit, from review): the exposure lives in `configs/expose_metrics.yml` and applies to control planes only when `var.talos_expose_metrics` is `true` — the same shape as `talos_disable_flannel`. The default is `false`, so other consumers of TKS and the test environment are unchanged; `vars/stable.tfvars` alone enables it. The README documents the toggle and the rollout facts below.

- `etcd`: `listen-metrics-urls: http://0.0.0.0:2381`
- `kube-controller-manager`: `bind-address: 0.0.0.0`
- `kube-scheduler`: `bind-address: 0.0.0.0`
- `kube-proxy`: `metrics-bind-address: 0.0.0.0:10249`

Security: the scheduler and controller-manager metrics ports keep TLS and RBAC (Prometheus scrapes them with its service-account token). etcd's metrics listener and kube-proxy's are plain HTTP, readable by anything that can reach the node network.

## Rollout

Applied to the stable cluster on 2026-08-21 and verified; the steps below record what it actually took.

1. `terraform apply --var-file="vars/stable.tfvars"` re-applies the machine configuration. The scheduler and controller-manager static pods pick their flags up on their own. The apiserver static pods also restart on any `cluster:` change, so the API blips briefly — run with `-parallelism=1` to keep that serial.
2. **etcd does not pick its flag up on its own.** Talos refuses `talosctl service etcd restart` by design ("doesn't support restart operation via API"), so each member needs a node reboot: `talosctl -n <ip> reboot`, strictly one control plane at a time, leader last, verifying quorum (`talosctl etcd status`) and port 2381 between each. Measured 40-90s per node.
3. kube-proxy is a bootstrap manifest, and a config re-apply does not rewrite the running DaemonSet (verified: the flag stayed absent). `talosctl -n <cp> upgrade-k8s --to 1.35.2` (the current version) re-rendered it with `--metrics-bind-address` and rolled it out. Side effect: the re-render also dropped a stale `kubectl.kubernetes.io/restartedAt` annotation from coredns, rolling it once. If kube-proxy ever rejects the flag outright on a future Kubernetes, drop that one block and leave the kube-proxy scrape disabled — the other three are independent.
4. Verified after rollout: 2381, 10257, 10259, and 10249 answer on all three control planes, 10249 on all three workers, all nodes Ready, quorum healthy on a new term.
5. The matching scrape enables land in Kubernetes-Manifests#658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

